### PR TITLE
fix(ios): fix sendMiFareCommand parameter and return value

### DIFF
--- a/ios/example/NDEF/app.js
+++ b/ios/example/NDEF/app.js
@@ -82,7 +82,7 @@ var deviceWindow = Ti.UI.createWindow({
   titleAttributes: { color: 'blue' }
 });
 
-var navDeviceWindow = Ti.UI.iOS.createNavigationWindow({
+var navDeviceWindow = Ti.UI.createNavigationWindow({
   window: deviceWindow
 });
 

--- a/ios/example/app.js
+++ b/ios/example/app.js
@@ -61,7 +61,7 @@ var deviceWindow = Ti.UI.createWindow({
   title: 'Mifare Sample',
   titleAttributes: { color: 'blue' }
 });
-var navDeviceWindow = Ti.UI.iOS.createNavigationWindow({
+var navDeviceWindow = Ti.UI.createNavigationWindow({
   window: deviceWindow
 });
 
@@ -81,7 +81,7 @@ nfcAdapter.addEventListener('didDetectTags', function (e) {
     Ti.API.info('didDetectTags with message' + (e.errorCode ? (' error code: ' + e.errorCode + ' error domain: ' + e.errorDomain + ' error description: ' + e.errorDescription) : ': Tag Detected'));
     logs.push('didDetectTags with message' + (e.errorCode ? (' error code: ' + e.errorCode + ' error domain: ' + e.errorDomain + ' error description: ' + e.errorDescription) : ': Tag Detected'));
     setData(logs);
-    
+
   var mifare = nfcAdapter.createTagTechMifareUltralight({'tag':e.tags[0]});
   mifare.addEventListener('didConnectTag', function (e) {
       Ti.API.info('didConnectTag with message' + (e.errorCode ? (' error code: ' + e.errorCode + ' error domain: ' + e.errorDomain + ' error description: ' + e.errorDescription) : ': MiFare Tag Connected'));

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 4.1.0
+version: 4.1.1
 apiversion: 2
 architectures: arm64 x86_64
 description: ti.nfc


### PR DESCRIPTION
With the help of the react-native module: https://github.com/revtel/react-native-nfc-manager/blob/main/ios/NfcManager%2BMifare.m I was able to fix `sendMiFareCommand` to read out different memory banks from a mifare ultralight tag.

**Issue**
Calling `mifare.sendMiFareCommand({data: [0x30,0x05]})` will run `3000` inside the module so it will always read the first memory block. The 2nd parameter didn't change anything. 
Also the return event didn't include the actual data.

![Screenshot_20240417-120904](https://github.com/tidev/ti.nfc/assets/4334997/5eef1190-909d-4a35-933d-199a82c40897)
only the yellow part is read.

**Fix**
Using the methods from the react-native module I was able to convert the array to the correct parameter to read different memory slots.
Returning the `hex` value to the app.

[ti.nfc-iphone-4.1.1.zip](https://github.com/tidev/ti.nfc/files/15009756/ti.nfc-iphone-4.1.1.zip)


